### PR TITLE
Fix press links

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,7 +364,7 @@
             <div class="card p-3 col-12 col-md-6 col-lg-2">
                 <div class="card-wrapper">
                     <div class="card-img">
-                        <a href="https://www.forbes.com/sites/billfischer/2019/02/15/it-takes-more-than-members-to-make-a-team/#10c487db4601" target="_blank"><img src="assets/images/new-york-times-logo-transparent-png-6-302x65.png" alt="Mobirise" title=""></a>
+                        <a href="https://www.nytimes.com/2019/02/13/science/science-research-psychology.html" target="_blank"><img src="assets/images/new-york-times-logo-transparent-png-6-302x65.png" alt="Mobirise" title=""></a>
                     </div>
                     <div class="card-box">
                         <h4 class="card-title pb-3 mbr-fonts-style display-7">Can Big Science Be Too Big?</h4>
@@ -376,7 +376,7 @@
             <div class="card p-3 col-12 col-md-6 col-lg-2">
                 <div class="card-wrapper">
                     <div class="card-img">
-                        <img src="assets/images/the-atlantic-magazine-logo-302x105.png" alt="Mobirise" title="">
+                        <a href="https://www.theatlantic.com/science/archive/2019/02/why-small-science-still-matters/582685/"><img src="assets/images/the-atlantic-magazine-logo-302x105.png" alt="Mobirise" title=""></a>
                     </div>
                     <div class="card-box">
                         <h4 class="card-title pb-3 mbr-fonts-style display-7">Small Teams of Scientists Have Fresher Ideas</h4>


### PR DESCRIPTION
Link to NYT story incorrectly links to Forbes story, Atlantic link missing. Fixed both.